### PR TITLE
census division documentation

### DIFF
--- a/docs/daikon/census_divisions.md
+++ b/docs/daikon/census_divisions.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: census-divisions/
+parent: Daikon REST API
+nav_order: 5
+---
+
+Census division is the general term for a Canadian geographic subregion (such as county, municipalité régionale de comté and regional district). They are typically established to facilitate the provision of public services (such as police or ambulance), but StatCan also utilizes these regions to help disseminate and organize statistical data.
+
+<style>
+td, th {
+   border: none!important;
+}
+</style>
+
+### GET /census-divisions/search ###
+{: .d-inline-block }
+
+Private Beta
+{: .label .label-purple }
+
+Returns basic attributes, such as name and type, of a given census division or all census divisions within a region. 
+
+| Request Parameter      | Details |
+| ----------- | ----------- |
+| region_code      | (Optional) The two letter internationally standardized ISO-3166-2 region code. Returns all census divisions in Canada if `null`|
+| census_division_name | (Optional) Census division name| 
+
+
+| Response Key      | type | Definition |
+| ----------- | ----------- |----------- |
+| id      | UUID | The unique 4-digit census division id (first two digits correspond to region) |
+| dguid      | string | [Dissemination Geographic Unique Identifier](https://www12.statcan.gc.ca/census-recensement/2021/ref/dict/az/definition-eng.cfm?ID=geo055) |
+| census_division_name      | string | Census division name |
+| census_division_type      | string | Census division type |
+| land_area     | numeric(32,2) | Land area of census division, in square kilometers (km<sup>2</sup>) |
+| region_code   | string | The two letter internationally standardized ISO-3166-2 region code |
+
+#### Example Requests ####
+<br>
+Specifying a region using the `region_code` will return all census divisions in that region.<br><br>
+`https://api.tm41m.com/census-divisions/search?region_code=ON`
+{: .d-inline-block }
+GET
+{: .label .label-blue }
+
+##### Response: #####
+
+```json
+{
+    "region_code": "ON"
+}
+```
+The attributes of a single census division can be observed by specifying the `census_division_name`. Special characters such as spaces and accents can be passed unencoded to the request.<br><br>
+`https://api.tm41m.com/census-divisions/search?census_division_name=La Matapédia`
+{: .d-inline-block }
+GET
+{: .label .label-blue }
+
+##### Response: #####
+
+```json
+{
+    "census_division_name": "La Matapédia"
+}
+```
+
+A request specifying both a `region_code` and a `census_division_name` will not succeed.<br><br>
+`https://api.tm41m.com/census-divisions/search?regino_code=ON&census_division_name=Wellington`
+{: .d-inline-block }
+GET
+{: .label .label-blue }
+
+##### Response: #####
+
+```json
+{
+    "error": "invalid parameters, refer to https://tm41m.io/docs/daikon/census_divisions.html"
+}
+```
+

--- a/docs/daikon/product_timeseries_metrics.md
+++ b/docs/daikon/product_timeseries_metrics.md
@@ -19,12 +19,13 @@ td, th {
 Public
 {: .label .label-green }
 
-Returns a set of product metrics given the `product_id`, `region_code`, `start_date` and `end_date`.
+Returns a set of product metrics given the `product_id`, `region_code`, `census_division_name`, `start_date` and `end_date`.
 
 | Request Parameter      | Details |
 | ----------- | ----------- |
 | product_id      | The product id |
 | region_code     | (Optional) The two letter internationally standardized ISO-3166-2 region code. Returns the global averages for Canada if `null`. | 
+| census_division_name | (Optional) Census division name. Refer to the `census-divisions/` endpoint documentation for more details. A request with this parameter will only succeed if the corresponding `region_code` is provided. Returns the global averages for the given region if `null`.  
 | start_date      | The starting datestamp to observe the metrics on. |
 | end_date        | (Optional) The ending datestamp to observe the metrics on. The default is the current date. | 
 
@@ -34,29 +35,55 @@ Returns a set of product metrics given the `product_id`, `region_code`, `start_d
 | product_id      | int | The product id |
 | currency      | string | The three letter code for the price's currency |
 | unit      | string | The unit of the listing e.g. (`'/ 1kg'`, `'/ lbs'` etc.) |
-| avg_price      | numeric(32,4) | The average price given all the sampled product listings on the date observed |
-| avg_price_chng      | numeric(32,4) | The average price change from the previous period where the sample is observed iff it has price information in both periods |
+| avg_price      | numeric(32,4) | The (arithmetic) mean price of all sampled product listings on the date observed |
+| avg_price_chng      | numeric(32,4) | The (arithmetic) mean price change from the previous period where the sample is observed iff it has price information in both periods |
 | product_listings      | int | The number of product listings on the date observed |
 | product_listings_rtn | int | The number of product listings retained from the previous period i.e. the listing was extracted both in the previous period and the current one |
 
 #### Example Requests ####
-`https://api.tm41m.com/product-metrics/search?product_id=1&region_code=ON&start_date=2023%2D08%2D11&end_date=2023%2D08%2D11`
+
 {: .d-inline-block }
 GET
 {: .label .label-blue }
+`https://api.tm41m.com/product-metrics/search?product_id=1&region_code=ON&start_date=2023%2D08%2D11&end_date=2023%2D08%2D11`
+
 
 ##### Response: #####
 
 ```json
 {
-    "calendar_date": "2023-06-11",
+    "calendar_date": "2023-08-11",
     "product_id": 1,
     "region_code": "ON",
+    "census_division_name": null,
     "currency": "CAD",
     "unit": "/ 1kg",
     "avg_price": 6.0424,
     "avg_price_chng": 0.0094,
     "product_listings": 1039,
     "product_listings_rtn": 876
+}
+```
+Note that many census division names include special characters such as spaces and accents. The unencoded names of such census divisions can be passed to a request as-is:<br>
+{: .d-inline-block }
+GET
+{: .label .label-blue }
+`https://api.tm41m.com/product-metrics/search?product_id=1&region_code=QC&start_date=2023-08-11&end_date=2023-08-11&census_division_name=La Côte-de-Gaspé`
+
+
+##### Response: #####
+
+```json
+{
+    "calendar_date": "2023-08-11",
+    "product_id": 1,
+    "region_code": "QC",
+    "census_division_name": "La Côte-de-Gaspé",
+    "currency": "CAD",
+    "unit": "/ 1kg",
+    "avg_price": "---",
+    "avg_price_chng": "---",
+    "product_listings": "---",
+    "product_listings_rtn": "---"
 }
 ```


### PR DESCRIPTION
- added documentation for the new `census_division_name` parameter in the `product-metrics/search` page, also included an example query that demonstrates how you can pass unencoded special chars into the request. The example response is unfinished cause I don't actually know what the metrics for this will be. 
- added a new `census-division/search` page which at this point is functioning as a spec sheet for how I have designed this new API endpoint. Includes some example requests that demonstrate the behavior I am going for, although the sample responses are not filled out yet. In the case of the query that searches by `region_code=ON`, I'm not actually sure how I would want to display the example results, since there will be many. Maybe just print one or two and then a `...`?